### PR TITLE
Adding JaCoCo maven plugin for Sonar integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,39 @@
     </dependencies>
 
     <profiles>
+    
+        <profile>
+            <id>jacoco</id>
+            <properties>
+                <it.jacoco.destFile>${java.io.tmpdir}/jacoco.data</it.jacoco.destFile>
+                <sonar.jacoco.itReportPath>${it.jacoco.destFile}</sonar.jacoco.itReportPath>
+            </properties>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                   <plugin>
+                       <groupId>org.jacoco</groupId>
+                       <artifactId>jacoco-maven-plugin</artifactId>
+                       <version>0.5.7.201204190339</version>
+                       <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <propertyName>it.failsafe.argLine</propertyName>
+                            <destFile>${it.jacoco.destFile}</destFile>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    
         <profile>
             <id>glassfish-embedded</id>
             <activation>
@@ -97,6 +130,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${version.maven.failsafe.plugin}</version>
+                        <configuration>
+                            <argLine>${it.failsafe.argLine}</argLine>
+                        </configuration>            
                         <executions>
                             <execution>
                                 <goals>
@@ -143,6 +179,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${version.maven.failsafe.plugin}</version>
+                        <configuration>
+                            <argLine>${it.failsafe.argLine}</argLine>
+                        </configuration>            
                         <executions>
                             <execution>
                                 <goals>
@@ -185,6 +224,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${version.maven.failsafe.plugin}</version>
+                        <configuration>
+                            <argLine>${it.failsafe.argLine}</argLine>
+                        </configuration>            
                         <executions>
                             <execution>
                                 <goals>
@@ -233,6 +275,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${version.maven.failsafe.plugin}</version>
+                        <configuration>
+                            <argLine>${it.failsafe.argLine}</argLine>
+                        </configuration>            
                         <executions>
                             <execution>
                                 <goals>
@@ -355,6 +400,10 @@
         <pluginRepository>
             <id>apache-snapshot</id>
             <url>https://repository.apache.org/content/repositories/snapshots/</url>
+        </pluginRepository>
+        <pluginRepository>
+            <id>maven-central</id>
+            <url>http://repo1.maven.org/maven2/</url>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
To add code coverage in your Sonar :

> > mvn install sonar:sonar -Pjacoco 
> > (or -Pjacoco,tomee ....)

Regards,
Jérémie.
