### PR TITLE
Using maven surefire plugin for IT test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,9 @@
         <profile>
             <id>jacoco</id>
             <properties>
-                <it.jacoco.destFile>${java.io.tmpdir}/jacoco.data</it.jacoco.destFile>
+                <jacoco.destFile>${project.build.directory}/jacoco.exec</jacoco.destFile>
+                <sonar.jacoco.reportPath>${jacoco.destFile}</sonar.jacoco.reportPath>
+                <it.jacoco.destFile>${project.build.directory}/jacocoit.exec</it.jacoco.destFile>
                 <sonar.jacoco.itReportPath>${it.jacoco.destFile}</sonar.jacoco.itReportPath>
             </properties>
             <activation>
@@ -90,16 +92,28 @@
                        <version>${version.jacoco}</version>
                        <executions>
                             <execution>
+                                <id>test</id>
+                                <phase>initialize</phase>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                                <configuration>
+                                    <propertyName>surefire.argLine</propertyName>
+                                    <destFile>${jacoco.destFile}</destFile>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>integration-test</id>
                                 <phase>pre-integration-test</phase>
                                 <goals>
                                     <goal>prepare-agent</goal>
                                 </goals>
+                                <configuration>
+                                    <propertyName>it.surefire.argLine</propertyName>
+                                    <destFile>${it.jacoco.destFile}</destFile>
+                                </configuration>
                             </execution>
                         </executions>
-                        <configuration>
-                            <propertyName>it.failsafe.argLine</propertyName>
-                            <destFile>${it.jacoco.destFile}</destFile>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -125,25 +139,6 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.maven.failsafe.plugin}</version>
-                        <configuration>
-                            <argLine>${it.failsafe.argLine}</argLine>
-                        </configuration>            
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>
@@ -170,25 +165,6 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.maven.failsafe.plugin}</version>
-                        <configuration>
-                            <argLine>${it.failsafe.argLine}</argLine>
-                        </configuration>            
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
 
         <profile>
@@ -217,25 +193,6 @@
                     <scope>test</scope>
                 </dependency>
             </dependencies>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>${version.maven.failsafe.plugin}</version>
-                        <configuration>
-                            <argLine>${it.failsafe.argLine}</argLine>
-                        </configuration>            
-                        <executions>
-                            <execution>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 
@@ -268,12 +225,39 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${version.maven.surefire.plugin}</version>
-                <configuration>
-                    <forkMode>never</forkMode>
-                </configuration>
+                <executions>
+                    <execution>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <skip>true</skip>
+                            <argLine>${surefire.argLine}</argLine>
+                            <forkMode>once</forkMode>
+                            <excludes>
+                              <exclude>**/*IT.java</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                          <skip>false</skip>
+                          <argLine>${it.surefire.argLine}</argLine>
+                          <forkMode>once</forkMode>
+                          <includes>
+                            <include>**/*IT.java</include>
+                          </includes>                                  
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Using the surefire plugin we have 31.2% test coverage in the sonar dashboard.

I can reuse the failsafe plugin but we have to deal with  classloader and  jacoco agent.

Regards,
Jérémie.
